### PR TITLE
Fix manual brightness when the sensor is disconnected

### DIFF
--- a/pc-app/BrightnessSensor.ConsoleApp.Tests/RuntimeStateTests.cs
+++ b/pc-app/BrightnessSensor.ConsoleApp.Tests/RuntimeStateTests.cs
@@ -217,6 +217,47 @@ public sealed class RuntimeStateTests
     }
 
     [Fact]
+    public void PendingManualBrightness_AppliesWithoutSensorTelemetry()
+    {
+        var state = new RuntimeStateStore();
+        var monitor = new FakeMonitorBrightness();
+        state.SetMonitors([monitor]);
+        state.SetBrightnessControlMode(BrightnessControlMode.Manual);
+        state.SetManualBrightnessPercent(42);
+
+        var processor = new MessageProcessor(state);
+
+        processor.ApplyPendingManualBrightness(
+            [new MonitorSession(monitor, CreateProcessor())],
+            CancellationToken.None);
+
+        Assert.Equal(1, monitor.SetBrightnessCalls);
+        Assert.Equal(42, monitor.LastSetBrightness);
+        Assert.Equal(42, state.GetSnapshot().LastManualAppliedBrightnessPercent);
+    }
+
+    [Fact]
+    public void ReEnteringManualMode_ReappliesTargetEvenWhenValueDidNotChange()
+    {
+        var state = new RuntimeStateStore();
+        var monitor = new FakeMonitorBrightness();
+        var session = new MonitorSession(monitor, CreateProcessor());
+        var processor = new MessageProcessor(state);
+
+        state.SetMonitors([monitor]);
+        state.SetBrightnessControlMode(BrightnessControlMode.Manual);
+        state.SetManualBrightnessPercent(42);
+        processor.ApplyPendingManualBrightness([session], CancellationToken.None);
+
+        state.SetBrightnessControlMode(BrightnessControlMode.Auto);
+        state.SetBrightnessControlMode(BrightnessControlMode.Manual);
+        processor.ApplyPendingManualBrightness([session], CancellationToken.None);
+
+        Assert.Equal(2, monitor.SetBrightnessCalls);
+        Assert.Equal(42, monitor.LastSetBrightness);
+    }
+
+    [Fact]
     public void SwitchingManualBackToAuto_UsesSensorDrivenProcessorAgain()
     {
         var state = new RuntimeStateStore();

--- a/pc-app/BrightnessSensor.ConsoleApp/Application/BrightnessApplication.cs
+++ b/pc-app/BrightnessSensor.ConsoleApp/Application/BrightnessApplication.cs
@@ -60,12 +60,15 @@ internal static class BrightnessApplication
                 new BrightnessProcessor(CreateBrightnessSettings(effectiveSettings))))
             .ToList();
 
+        var messageProcessor = new MessageProcessor(stateStore);
+
         if (!TryConnectSensor(
                 configPath,
                 serialBaudRate,
                 discoveryTimeoutMs,
                 monitorSessions,
                 stateStore,
+                messageProcessor,
                 cancellationToken,
                 ref config,
                 ref effectiveSettings,
@@ -76,7 +79,6 @@ internal static class BrightnessApplication
         }
 
         stateStore.SetLifecycle(AppLifecycleState.Running, "Running.");
-        var messageProcessor = new MessageProcessor(stateStore);
 
         if (firstMessage is not null)
         {
@@ -91,6 +93,7 @@ internal static class BrightnessApplication
                 ref effectiveSettings,
                 monitorSessions,
                 stateStore);
+            messageProcessor.ApplyPendingManualBrightness(monitorSessions, cancellationToken);
 
             var readResult = sensorReader.TryReadMessage();
             if (readResult.Status == SensorReadStatus.TimeoutOrEmpty)
@@ -172,6 +175,7 @@ internal static class BrightnessApplication
         int discoveryTimeoutMs,
         IReadOnlyList<MonitorSession> monitorSessions,
         RuntimeStateStore stateStore,
+        MessageProcessor messageProcessor,
         CancellationToken cancellationToken,
         ref AppConfig config,
         ref ResolvedAppSettings effectiveSettings,
@@ -192,6 +196,7 @@ internal static class BrightnessApplication
                 ref effectiveSettings,
                 monitorSessions,
                 stateStore);
+            messageProcessor.ApplyPendingManualBrightness(monitorSessions, cancellationToken);
 
             stateStore.SetLifecycle(AppLifecycleState.Waiting, "Waiting for sensor telemetry...");
             stateStore.ClearLatestSensor();

--- a/pc-app/BrightnessSensor.ConsoleApp/Application/BrightnessApplication.cs
+++ b/pc-app/BrightnessSensor.ConsoleApp/Application/BrightnessApplication.cs
@@ -60,12 +60,15 @@ internal static class BrightnessApplication
                 new BrightnessProcessor(CreateBrightnessSettings(effectiveSettings))))
             .ToList();
 
+        var messageProcessor = new MessageProcessor(stateStore);
+
         if (!TryConnectSensor(
                 configPath,
                 serialBaudRate,
                 discoveryTimeoutMs,
                 monitorSessions,
                 stateStore,
+                messageProcessor,
                 cancellationToken,
                 ref config,
                 ref effectiveSettings,
@@ -76,7 +79,6 @@ internal static class BrightnessApplication
         }
 
         stateStore.SetLifecycle(AppLifecycleState.Running, "Running.");
-        var messageProcessor = new MessageProcessor(stateStore);
 
         if (firstMessage is not null)
         {
@@ -91,6 +93,7 @@ internal static class BrightnessApplication
                 ref effectiveSettings,
                 monitorSessions,
                 stateStore);
+            messageProcessor.ApplyPendingManualBrightness(monitorSessions, cancellationToken);
 
             var readResult = sensorReader.TryReadMessage();
             if (readResult.Status == SensorReadStatus.TimeoutOrEmpty)
@@ -119,6 +122,7 @@ internal static class BrightnessApplication
                         discoveryTimeoutMs,
                         monitorSessions,
                         stateStore,
+                        messageProcessor,
                         cancellationToken,
                         ref config,
                         ref effectiveSettings,
@@ -172,6 +176,7 @@ internal static class BrightnessApplication
         int discoveryTimeoutMs,
         IReadOnlyList<MonitorSession> monitorSessions,
         RuntimeStateStore stateStore,
+        MessageProcessor messageProcessor,
         CancellationToken cancellationToken,
         ref AppConfig config,
         ref ResolvedAppSettings effectiveSettings,
@@ -192,6 +197,7 @@ internal static class BrightnessApplication
                 ref effectiveSettings,
                 monitorSessions,
                 stateStore);
+            messageProcessor.ApplyPendingManualBrightness(monitorSessions, cancellationToken);
 
             stateStore.SetLifecycle(AppLifecycleState.Waiting, "Waiting for sensor telemetry...");
             stateStore.ClearLatestSensor();

--- a/pc-app/BrightnessSensor.ConsoleApp/Application/MessageProcessor.cs
+++ b/pc-app/BrightnessSensor.ConsoleApp/Application/MessageProcessor.cs
@@ -98,6 +98,29 @@ internal sealed class MessageProcessor(RuntimeStateStore stateStore)
         Task.WaitAll([.. monitorTasks], cancellationToken);
     }
 
+    public void ApplyPendingManualBrightness(
+        IReadOnlyList<MonitorSession> monitorSessions,
+        CancellationToken cancellationToken)
+    {
+        if (monitorSessions.Count == 0)
+        {
+            return;
+        }
+
+        if (_stateStore.IsPaused || _stateStore.BrightnessControlMode != BrightnessControlMode.Manual)
+        {
+            return;
+        }
+
+        var snapshot = _stateStore.GetSnapshot();
+        if (snapshot.LastManualAppliedBrightnessPercent == snapshot.ManualBrightnessPercent)
+        {
+            return;
+        }
+
+        ApplyManualBrightness(monitorSessions, cancellationToken);
+    }
+
     private void ApplyManualBrightness(
         IReadOnlyList<MonitorSession> monitorSessions,
         CancellationToken cancellationToken)

--- a/pc-app/BrightnessSensor.ConsoleApp/Runtime/RuntimeStateStore.cs
+++ b/pc-app/BrightnessSensor.ConsoleApp/Runtime/RuntimeStateStore.cs
@@ -650,6 +650,10 @@ internal sealed class RuntimeStateStore
             {
                 _forceNextAutoBrightnessApply = true;
             }
+            else if (previousMode != BrightnessControlMode.Manual && mode == BrightnessControlMode.Manual)
+            {
+                _lastManualAppliedBrightnessPercent = null;
+            }
 
             _statusMessage = mode == BrightnessControlMode.Auto
                 ? "Running."


### PR DESCRIPTION
## Summary
- allow manual brightness writes to run even when no sensor telemetry is currently available
- trigger pending manual brightness applies from the main runtime loop and from the sensor reconnect loop
- reset the cached manual-apply marker when re-entering manual mode, and cover the disconnected/manual scenarios with tests

## Root cause
Manual brightness updates were only applied from `MessageProcessor.ProcessMessage(...)`, which meant the desktop app could change monitor brightness in manual mode only after a sensor message arrived. When the sensor was disconnected, the UI could enter manual mode, but no brightness write path ever ran.

## Validation
- `dotnet test brightness-sensor.sln`

Closes #10